### PR TITLE
Resolve #31 with cart badge for number of added cart items

### DIFF
--- a/src/main/webapp/WEB-INF/jspf/common/components/header.jspf
+++ b/src/main/webapp/WEB-INF/jspf/common/components/header.jspf
@@ -28,28 +28,38 @@
 </nav>
 
 <!-- MAIN NAVBAR -->
-<nav class="navbar navbar-expand-lg navbar-light shadow bg-light sticky-top" data-navbar-on-scroll="data-navbar-on-scroll">
+<nav class="navbar navbar-expand-lg navbar-light shadow bg-light sticky-top"
+     data-navbar-on-scroll="data-navbar-on-scroll">
   <div class="container">
     <a class="navbar-brand d-inline-flex" href="/">
-      <img class="d-inline-block" src="<%= request.getContextPath() + "assets/img/gallery/logo.svg"%>" alt="logo" />
+      <img class="d-inline-block" src="<%= request.getContextPath() + "assets/img/gallery/logo.svg"%>" alt="logo"/>
       <span class="text-1000 fs-3 fw-bold ms-2 text-gradient">FFood</span>
     </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
+            aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
-    <div class="collapse navbar-collapse pt-3 pb-2 py-lg-2 w-100" id="navbarSupportedContent"> 
+    <div class="collapse navbar-collapse pt-3 pb-2 py-lg-2 w-100" id="navbarSupportedContent">
       <form class="d-flex col">
         <div class="input-group-icon flex-grow-1 mx-md-5 pe-2">
           <i class="fas fa-search input-box-icon text-primary"></i>
-          <input class="form-control border-1 input-box bg-100" type="search" placeholder="Tìm món ăn" aria-label="Tìm món ăn" id="btn-search" onblur="searchFood()"/>
+          <input class="form-control border-1 input-box bg-100" type="search" placeholder="Tìm món ăn"
+                 aria-label="Tìm món ăn" id="btn-search" onblur="searchFood()"/>
         </div>
-        <button class="nav-icon text-decoration-none my-auto fas fa-fw fa-cart-arrow-down text-primary fs-2 mx-2" data-bs-toggle="modal" data-bs-target="#cart-modal"></button>             
+        <button type="button" class="btn p-0 position-relative nav-icon text-decoration-none my-auto text-primary fs-2 mx-2"
+                data-bs-toggle="modal" data-bs-target="#cart-modal">
+          <i class="fas fa-fw fa-cart-arrow-down"></i>
+          <span id="cart-badge" class="position-absolute top-0 start-100 translate-middle px-2 fs-0 bg-danger rounded-circle text-white">
+            <span class="visually-hidden">Giỏ hàng</span>
+          </span>
+        </button>
         <c:choose>
           <c:when test="${isLoggedIn}">
             <div class="dropdown">
-              <button class="btn btn-secondary text-white ms-2 px-3 px-lg-4" data-bs-toggle="dropdown" aria-expanded="false" type="button">
+              <button class="btn btn-secondary text-white ms-2 px-3 px-lg-4" data-bs-toggle="dropdown"
+                      aria-expanded="false" type="button">
                 <i class="fas fa-user me-2"></i>
-                ${username}
+                  ${username}
               </button>
               <ul class="dropdown-menu text-small shadow ms-2 w-100">
                 <li><a class="dropdown-item" href="/user#info">Tài khoản của tôi</a></li>
@@ -59,7 +69,8 @@
             </div>
           </c:when>
           <c:otherwise>
-            <button class="btn btn-primary text-white ms-2 px-3 px-lg-4" data-bs-toggle="modal" data-bs-target="#login-modal" type="button">
+            <button class="btn btn-primary text-white ms-2 px-3 px-lg-4" data-bs-toggle="modal"
+                    data-bs-target="#login-modal" type="button">
               <i class="fas fa-user me-2"></i>
               Đăng nhập
             </button>

--- a/src/main/webapp/WEB-INF/jspf/common/components/header.jspf
+++ b/src/main/webapp/WEB-INF/jspf/common/components/header.jspf
@@ -46,10 +46,10 @@
           <input class="form-control border-1 input-box bg-100" type="search" placeholder="Tìm món ăn"
                  aria-label="Tìm món ăn" id="btn-search" onblur="searchFood()"/>
         </div>
-        <button type="button" class="btn p-0 position-relative nav-icon text-decoration-none my-auto text-primary fs-2 mx-2"
+        <button type="button" class="btn pe-2 py-0 position-relative nav-icon text-decoration-none my-auto text-primary fs-2 me-4"
                 data-bs-toggle="modal" data-bs-target="#cart-modal">
           <i class="fas fa-fw fa-cart-arrow-down"></i>
-          <span id="cart-badge" class="position-absolute top-0 start-100 translate-middle px-2 fs-0 bg-danger rounded-circle text-white">
+          <span id="cart-badge" class="position-absolute top-0 start-100 translate-middle px-2 fs-0 bg-danger rounded-pill text-white">
             <span class="visually-hidden">Giỏ hàng</span>
           </span>
         </button>

--- a/src/main/webapp/WEB-INF/jspf/common/components/header.jspf
+++ b/src/main/webapp/WEB-INF/jspf/common/components/header.jspf
@@ -46,7 +46,7 @@
           <input class="form-control border-1 input-box bg-100" type="search" placeholder="Tìm món ăn"
                  aria-label="Tìm món ăn" id="btn-search" onblur="searchFood()"/>
         </div>
-        <button type="button" class="btn pe-2 py-0 position-relative nav-icon text-decoration-none my-auto text-primary fs-2 me-4"
+        <button type="button" class="btn ps-1 pe-2 py-0 position-relative nav-icon text-decoration-none my-auto text-primary fs-2 me-4"
                 data-bs-toggle="modal" data-bs-target="#cart-modal">
           <i class="fas fa-fw fa-cart-arrow-down"></i>
           <span id="cart-badge" class="position-absolute top-0 start-100 translate-middle px-2 fs-0 bg-danger rounded-pill text-white">

--- a/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
+++ b/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
@@ -91,7 +91,14 @@
   } else {
     document.getElementById("btnSubmit").disabled = false;
     cartBadge.classList.remove("d-none");
+
     // Set the cart badge text to the number of rows
-    cartBadge.innerText = numRows;
+    if (numRows > 99) {
+      cartBadge.innerText = "99+";
+    } else if (numRows < 0) {
+      cartBadge.innerText = "0";
+    } else {
+      cartBadge.innerText = numRows;
+    }
   }
 </script>

--- a/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
+++ b/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
@@ -4,22 +4,23 @@
 <div class="modal" tabindex="-1" id="cart-modal">
   <div class="modal-dialog modal-xl modal-dialog-scrollable modal-dialog-centered">
     <div class="modal-content">
-      <form action="checkout" method="POST">
-        <div class="modal-header border-bottom-0">
-          <h5 class="modal-title" id="exampleModalLabel">Giỏ hàng</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body">
+      <div class="modal-header border-bottom-0">
+        <h5 class="modal-title" id="exampleModalLabel">Giỏ hàng</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <%-- Putting form inside modal body ensures the modal's scrollability --%>
+        <form id="cart-form" action="checkout" method="POST">
           <div class="table-responsive">
             <table id="cart-table" class="table">
               <thead>
-                <tr>
-                  <th scope="col">Món ăn/Đồ uống</th>
-                  <th scope="col">Đơn giá</th>
-                  <th scope="col">Số lượng</th>
-                  <th scope="col">Số tiền</th>
-                  <th scope="col">Thao tác</th>
-                </tr>
+              <tr>
+                <th scope="col">Món ăn/Đồ uống</th>
+                <th scope="col">Đơn giá</th>
+                <th scope="col">Số lượng</th>
+                <th scope="col">Số tiền</th>
+                <th scope="col">Thao tác</th>
+              </tr>
               </thead>
               <tbody>
               <p style="color: red;">${mess}</p>
@@ -28,40 +29,69 @@
                 <input type="text" name="fid" value="${cart.food.foodID}" hidden>
                 <tr class="align-middle">
                   <td class="table-image-cell">
-                    <img src="${cart.food.imageURL}" alt="${cart.food.foodName}" class="me-3" />
-                    ${cart.food.foodName}
+                    <img src="${cart.food.imageURL}" alt="${cart.food.foodName}" class="me-3"/>
+                      ${cart.food.foodName}
                   </td>
                   <td>${cart.food.getFoodPriceFormat()}</td>
                   <td>
-                    <input type="number" name="quantity-${cart.food.foodID}" value="${cart.foodQuantity}" min="1" />
+                    <input type="number" name="quantity-${cart.food.foodID}" value="${cart.foodQuantity}" min="1"/>
                   </td>
                   <td>
-                <c:set var="productPrice" value="${Double.parseDouble(cart.food.foodPrice) * cart.foodQuantity}" />
-                <c:set var="totalPrice" value="${totalPrice + productPrice}" />
-                <fmt:formatNumber type="number" pattern="###,###" value="${Double.parseDouble(cart.food.foodPrice) * cart.foodQuantity}" />đ
-                </td>
-                <td>
+                    <c:set var="productPrice" value="${Double.parseDouble(cart.food.foodPrice) * cart.foodQuantity}"/>
+                    <c:set var="totalPrice" value="${totalPrice + productPrice}"/>
+                    <fmt:formatNumber type="number" pattern="###,###"
+                                      value="${Double.parseDouble(cart.food.foodPrice) * cart.foodQuantity}"/>đ
+                  </td>
+                  <td>
                     <a href="deleteCart?fid=${cart.food.foodID}">
-                        <button type="button" class="btn btn-sm btn-danger" >Xóa</button>
+                      <button type="button" class="btn btn-sm btn-danger"
+                              onclick="return confirm('Bạn có muốn xóa Món này khỏi Giỏ hàng không?')">Xóa
+                      </button>
                     </a>
-                </td>
+                  </td>
                 </tr>
               </c:forEach>
               </tbody>
             </table>
           </div>
-        </div>
-        <div class="modal-footer">
-          <div class="d-flex flex-row align-items-center justify-content-end w-100">
-            <div class="col text-end me-3">
-              <h5 class ="m-0">Tổng thanh toán: <fmt:formatNumber type="number" pattern="###,###" value="${totalPrice}" />đ</h5>
-            </div>
-            <div class="col-xl-2 col-lg-3 col-md-4 col-sm-4 align-self-end text-end">
-              <button type="submit" class="btn btn-primary w-100" id="btnSubmit" name="btnSubmit" value="Checkout">Thanh toán</button>
-            </div>
+        </form>
+      </div>
+      <div class="modal-footer">
+        <div class="d-flex flex-row align-items-center justify-content-end w-100">
+          <div class="col text-end me-3">
+            <h5 class="m-0">Tổng thanh toán: <fmt:formatNumber type="number" pattern="###,###"
+                                                               value="${totalPrice}"/>đ</h5>
+          </div>
+          <div class="col-xl-2 col-lg-3 col-md-4 col-sm-4 align-self-end text-end">
+            <%-- To solve the issue of submit button outside of the form element, just add "form" attribute --%>
+            <button type="submit" class="btn btn-primary w-100" id="btnSubmit" name="btnSubmit" form="cart-form" value="Checkout">Thanh
+              toán
+            </button>
           </div>
         </div>
-      </form>
+      </div>
     </div>
   </div>
 </div>
+
+<script>
+  // Get the cart table element
+  const cartTable = document.getElementById("cart-table");
+
+  // Get the cart badge element
+  const cartBadge = document.getElementById("cart-badge");
+
+  // Get the number of rows in the cart table
+  const numRows = cartTable.getElementsByTagName("tbody")[0].getElementsByTagName("tr").length;
+
+  // If there are no rows, disable the submit button and remove the cart badge
+  if (numRows === 0) {
+    document.getElementById("btnSubmit").disabled = true;
+    cartBadge.classList.add("d-none");
+  } else {
+    document.getElementById("btnSubmit").disabled = false;
+    cartBadge.classList.remove("d-none");
+    // Set the cart badge text to the number of rows
+    cartBadge.innerText = numRows;
+  }
+</script>


### PR DESCRIPTION
Added a cart badge with the following features:
- Autohides when there is no cart item (cart is empty)
- Displays the number of added items (1-99 items are displayed normally, beyond that "99+" is displayed instead)

Also fixed a bug preventing cart modal from being scrollable when there are too many cart items.