### PR TITLE
Update Cart modal UI + Fix Cart bugs

### DIFF
--- a/src/main/java/Controllers/AddToCartController.java
+++ b/src/main/java/Controllers/AddToCartController.java
@@ -79,7 +79,12 @@ public class AddToCartController extends HttpServlet {
         CartItem item = new CartItem(food, Integer.parseInt(quantity));
         cart.addItem(item);
         session.setAttribute("cart", cart);
-        response.sendRedirect("home");
+
+        // Remove empty cart message if it exists
+        if (session.getAttribute("mess") != null) {
+            session.removeAttribute("mess");
+        }
+        response.sendRedirect("/");
 
     }
 

--- a/src/main/java/Controllers/CheckoutController.java
+++ b/src/main/java/Controllers/CheckoutController.java
@@ -67,35 +67,38 @@ public class CheckoutController extends HttpServlet {
           throws ServletException, IOException {
 
     HttpSession session = request.getSession();
-    int userID = (Integer) session.getAttribute("userID");
-    AccountDAO accountDAO = new AccountDAO();
-    Account currentAccount = accountDAO.getAccount(userID);
+    
+    if (session.getAttribute("userID") != null) {
+        int userID = (Integer) session.getAttribute("userID");
+        // Người dùng có đăng nhập -> lấy thông tin người dùng để autofill
+        AccountDAO accountDAO = new AccountDAO();
+        Account currentAccount = accountDAO.getAccount(userID);
 
-    request.setAttribute("currentAccount", currentAccount);
-    //</editor-fold>
+        request.setAttribute("currentAccount", currentAccount);
+        //<editor-fold defaultstate="collapsed" desc="Lấy thông tin khách hàng nếu có">
+        // This info will be used to preload the "Thông tin của tôi" form
+        // Default int values are assigned 0 instead of null
+        if (currentAccount.getCustomerID() != 0) {
+          //<editor-fold defaultstate="collapsed" desc="Get customer info">
+          int customerID = currentAccount.getCustomerID();
+          CustomerDAO customerDAO = new CustomerDAO();
+          Customer customer = customerDAO.getCustomer(customerID);
 
-    //<editor-fold defaultstate="collapsed" desc="Get customer info if it exists">
-    // This info will be used to preload the "Thông tin của tôi" form
-    // Default int values are assigned 0 instead of null
-    if (currentAccount.getCustomerID() != 0) {
-      int customerID = currentAccount.getCustomerID();
-      CustomerDAO customerDAO = new CustomerDAO();
-      Customer customer = customerDAO.getCustomer(customerID);
+          request.setAttribute("customer", customer);
+          //</editor-fold>
 
-      request.setAttribute("customer", customer);
-    }
-    //</editor-fold>
+        }
+        //</editor-fold>
+      }
 
     // Lưu trữ URL hiện tại vào session attribute
     session.setAttribute("previousUrl", request.getRequestURI());
     Cart cart = (Cart) session.getAttribute("cart");
-    if (cart == null) {
-      request.setAttribute("mess", "Giỏ hàng trống, vui lòng chọn món để thanh toán");
-      request.getRequestDispatcher("home").forward(request, response);
-      return;
-    }
-    if (cart == null) {
+    if (cart == null || cart.getItems().isEmpty()) {
       cart = new Cart();
+      session.setAttribute("mess", "Giỏ hàng của bạn đang trống, vui lòng thêm món để thanh toán.");
+      response.sendRedirect("/");
+      return;
     }
     String quantityParam = "";
     for (CartItem cartItem : cart.getItems()) {
@@ -323,13 +326,11 @@ public class CheckoutController extends HttpServlet {
 //        OrderDAO odao = new OrderDAO();
 //        odao.insertOrderStatusNotCFYet(cart);
       Cart cart = (Cart) session.getAttribute("cart");
-      if (cart == null) {
-        request.setAttribute("mess", "Giỏ hàng trống, vui lòng chọn món để thanh toán");
-        request.getRequestDispatcher("home").forward(request, response);
-        return;
-      }
-      if (cart == null) {
+      if (cart == null || cart.getItems().isEmpty()) {
         cart = new Cart();
+        session.setAttribute("mess", "Giỏ hàng của bạn đang trống, vui lòng thêm món để thanh toán.");
+        response.sendRedirect("/");
+        return;
       }
       String quantityParam = "";
       for (CartItem cartItem : cart.getItems()) {
@@ -357,6 +358,11 @@ public class CheckoutController extends HttpServlet {
         session.setAttribute("quantity-" + foodId, quantityParam);
       }
       session.setAttribute("cart", cart);
+
+      // Remove empty cart message if it exists
+      if (session.getAttribute("mess") != null) {
+        session.removeAttribute("mess");
+      }
 
       request.getRequestDispatcher("checkout.jsp").forward(request, response);
     }

--- a/src/main/java/Controllers/DeleteCartController.java
+++ b/src/main/java/Controllers/DeleteCartController.java
@@ -34,7 +34,7 @@ public class DeleteCartController extends HttpServlet {
         String foodId = request.getParameter("fid");
         Cart cart = (Cart) object;
         cart.removeItem(Integer.parseInt(foodId));
-        response.sendRedirect("home");
+        response.sendRedirect("/");
     } 
 
     // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">

--- a/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
+++ b/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
@@ -93,6 +93,14 @@
     </div>
 </div>
 
+<style>
+  #cart-modal input[type=number]::-webkit-inner-spin-button, 
+  #cart-modal input[type=number]::-webkit-outer-spin-button { 
+    -webkit-appearance: none; 
+    margin: 0; 
+  }
+</style>
+
 <script>
     // Get the cart table element
     const cartTable = document.getElementById("cart-table");
@@ -121,20 +129,23 @@
         }
     }
 
+    // Restrict user input to reject non-numeric characters
+    // except for navigation keys and backspace/delete
     $('.quantity-input').on('keydown', (e) => {
       let key = e.key;
       let isDigit = /^\d$/.test(key);
-      let isException = key === 'ArrowLeft' 
-        || key === 'ArrowRight' 
-        || key === 'Backspace'
-        || key === 'Delete';
+      let target = $(e.target);
+      let allowedKeys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Backspace', 'Delete'];
+      let isException = allowedKeys.includes(key);
 
-      // // TODO fix this mess here
-      // if (isDigit) {
-      //   if (this.val().toString().length >= 2) {
-      //     e.preventDefault();
-      //   }
-      // }
+      // Prevents the user from typing more than 2 digits
+      // If target is of HTML input element, use e.target.value
+      // If target is of jQuery object, use $(e.target).val()
+      if (isDigit) {
+        if (target.val().length >= 2) {
+          e.preventDefault();
+        }
+      }
       
       // Check if the key is a number
       if (!isDigit && !isException) {
@@ -142,29 +153,46 @@
       }
     })
 
-    // Add event listener for quantity input change event using event delegation
+    let oldQuantity = 1;
+    // Set the old quantity variable to the value of the input field (before the user types anything), 
+    // so that this will be used to restore the original quantity in case
+    // the new quantity is invalid
+    $('.quantity-input').on('focus', (e) => {
+      const target = $(e.target);      
+      oldQuantity = parseInt(target.val(), 10);
+    })
+
+    // Validates the user quantity input only when the user clicks outside of the input field
+    // instead of immediately upon value change. Because we want the user to safely delete the old number
+    // and input a new one without the price values going crazy
     $('.quantity-input').on('blur', (e) => {
-      // Get the parent row of the input field
-      const row = event.target.closest("tr");
-      const target = e.target;
+      // Get the parent table row of the input field
+      const tableRow = event.target.closest("tr");
+      const target = $(e.target);
       // Get the price per unit of the food from the data attribute or other source
-      const pricePerUnitText = row.querySelector("td:nth-child(2)").textContent.trim();
+      const pricePerUnitText = tableRow.querySelector("td:nth-child(2)").textContent.trim();
       const pricePerUnit = parseFloat(pricePerUnitText.replace("đ", "").replace(",", ""));
       
       // Get the quantity entered by the user
       const currentQuantity = parseInt(event.target.value, 10);
 
-      // // Validates the user input, making sure it is within 1-10
-      // let newQuantity =
-      //   !isNaN(currentQuantity) && currentQuantity >= 1 && currentQuantity < 10 // user input is valid
-      //     ? currentQuantity
-      //     : 1; // default to 1
-      // target.val(newQuantity); // TODO fix this mess here
+      // Validates the user input, making sure it is within 1-10
+      let newQuantity =
+        !isNaN(currentQuantity) && currentQuantity >= 1 && currentQuantity <= 10 // user input is valid
+          ? currentQuantity
+          : oldQuantity; // This is retrieve before the user typed anything, so this acts as the backup value
+
+      // https://stackoverflow.com/questions/45069106/jquery-doesnt-handle-event-target-properly-why
+      target.val(newQuantity);
       
       // Calculate the new product price
-      const productPrice = pricePerUnit * newQuantity;
+      const itemTotal = pricePerUnit * newQuantity;
+      
       // Update the product price cell in the same row
+      // Format the total price string so that it can be displayed correctly to the user
+      formattedItemTotal = itemTotal.toLocaleString();
       $(tableRow).find(".item-total").html(formattedItemTotal + " đ");
+      
       // Calculate and update the total price
       updateTotalPrice();
     })
@@ -184,7 +212,7 @@
         totalPriceElement.textContent = "Tổng thanh toán: " + totalPrice.toLocaleString() + "đ";
     }
 
-        /**
+    /**
      * Increments the value of a field by 1 when triggered by an event.
      *
      * @param {Event} e - The event object.
@@ -240,12 +268,12 @@
      */
     function getPrice(str) {
       let trimmedStr = str
-        .substring(0, str.length - 2) // Removes currency symbol and space before it
+        .replace(" đ", "") // Removes currency symbol and space before it
         .replace(",", ""); // Removes thousand separators
       return parseInt(trimmedStr);
     }
 
-    $(".input-group").on("click", ".button-plus", function (e) {
+    $(".input-group").on("click", ".button-plus", (e) => {
       let quantity = incrementValue(e);
       let target = $(e.target);
       let tableRow = target.closest("tr");
@@ -260,7 +288,7 @@
       updateTotalPrice();
     });
 
-    $(".input-group").on("click", ".button-minus", function (e) {
+    $(".input-group").on("click", ".button-minus", (e) => {
       let quantity = decrementValue(e);
       let target = $(e.target);
       let tableRow = target.closest("tr");

--- a/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
+++ b/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
@@ -3,69 +3,88 @@
 <!-- Cart -->
 <div class="modal" tabindex="-1" id="cart-modal">
     <div class="modal-dialog modal-xl modal-dialog-scrollable modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header border-bottom-0">
-                <h5 class="modal-title" id="exampleModalLabel">Giỏ hàng</h5>
+        <div class="modal-content px-4 py-3">
+            <div class="modal-header pb-0 border-bottom-0">
+                <h4 class="modal-title" id="exampleModalLabel">Giỏ hàng</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
                 <%-- Putting form inside modal body ensures the modal's scrollability --%>
                 <form id="cart-form" action="checkout" method="POST">
                     <div class="table-responsive">
-                        <table id="cart-table" class="table">
+                        <table id="cart-table" class="table table-sm table-hover mb-0">
                             <thead>
                                 <tr>
                                     <th scope="col">Món ăn/Đồ uống</th>
-                                    <th scope="col">Đơn giá</th>
+                                    <th scope="col" style="min-width: 6em">Đơn giá</th>
                                     <th scope="col">Số lượng</th>
-                                    <th scope="col">Số tiền</th>
+                                    <th scope="col" style="min-width: 6em">Số tiền</th>
                                     <th scope="col">Thao tác</th>
                                 </tr>
                             </thead>
-                            <tbody>
+                            <tbody class="table-group-divider">
                             <p style="color: red;">${mess}</p>
                             <c:set var="totalPrice" value="0"></c:set>
                             <c:forEach var="cart" items="${sessionScope['cart'].items}">
                                 <input type="text" name="fid" value="${cart.food.foodID}" hidden>
                                 <tr class="align-middle">
+                                    <!-- Image and Food name -->
                                     <td class="table-image-cell">
                                         <img src="${cart.food.imageURL}" alt="${cart.food.foodName}" class="me-3"/>
                                         ${cart.food.foodName}
                                     </td>
-                                    <td>${cart.food.getFoodPriceFormat()}</td>
+                                    <!-- Price -->
+                                    <td class="item-price">${cart.food.getFoodPriceFormat()}</td>
+                                    <!-- Quantity -->
+                                    <!-- https://codepen.io/anitaparmar26/pen/BaLYMeN -->
                                     <td>
-                                        <input type="number" class="quantity-input" name="quantity-${cart.food.foodID}" value="${cart.foodQuantity}" min="1"/>
+                                        <div class="d-flex input-group align-items-center">
+                                          <input type="button" value="-" class="btn btn-outline-dark border border-dark border-1 button-minus px-2 py-1" data-field="quantity-${cart.food.foodID}">
+                                          <input type="number" step="1" min="1" max="10" maxlength="2" style="width: 2em;" class="quantity-input quantity-field border border-dark border-1 border-start-0 border-end-0 text-center py-1" name="quantity-${cart.food.foodID}" value="${cart.foodQuantity}">
+                                          <input type="button" value="+" class="btn btn-outline-dark border border-dark border-1 button-plus px-2 py-1" data-field="quantity-${cart.food.foodID}">
+                                        </div>
                                     </td>
+                                    <!-- Total -->
+                                    <td class="item-total">
+                                      <c:set var="productPrice" value="${Double.parseDouble(cart.food.foodPrice) * cart.foodQuantity}"/>
+                                      <c:set var="totalPrice" value="${totalPrice + productPrice}"/>
+                                      <fmt:formatNumber type="number" pattern="###,###"
+                                                        value="${Double.parseDouble(cart.food.foodPrice) * cart.foodQuantity}"/> đ
+                                    </td>
+                                    <!-- Remove -->
                                     <td>
-                                <c:set var="productPrice" value="${Double.parseDouble(cart.food.foodPrice) * cart.foodQuantity}"/>
-                                <c:set var="totalPrice" value="${totalPrice + productPrice}"/>
-                                <fmt:formatNumber type="number" pattern="###,###"
-                                                  value="${Double.parseDouble(cart.food.foodPrice) * cart.foodQuantity}"/>đ
-                                </td>
-                                <td>
-                                    <a href="deleteCart?fid=${cart.food.foodID}">
-                                        <button type="button" class="btn btn-sm btn-danger"
-                                                onclick="return confirm('Bạn có muốn xóa Món này khỏi Giỏ hàng không?')">Xóa
-                                        </button>
-                                    </a>
-                                </td>
+                                        <a href="deleteCart?fid=${cart.food.foodID}" 
+                                                    class="d-flex btn btn-sm btn-outline-danger align-items-center px-3"
+                                                    style="width:fit-content;"
+                                                    onclick="return confirm('Bạn có muốn xóa Món này khỏi Giỏ hàng không?')">
+                                                    <i class="ph-bold ph-trash fs-1 me-2"></i>
+                                                    Xóa
+                                        </a>
+                                    </td>
                                 </tr>
                             </c:forEach>
                             </tbody>
+                            <tfoot class="table-group-divider">
+                              <th colspan="5" class="text-end">
+                                <h5 id="grand-total" class="mt-2">Tổng thanh toán: <fmt:formatNumber type="number" pattern="###,###"
+                                  value="${totalPrice}"/> đ</h5>
+                              </th>
+                            </tfoot>
                         </table>
                     </div>
                 </form>
             </div>
-            <div class="modal-footer">
+            <div class="modal-footer pt-0">
                 <div class="d-flex flex-row align-items-center justify-content-end w-100">
-                    <div class="col text-end me-3">
-                        <h5 class="m-0">Tổng thanh toán: <fmt:formatNumber type="number" pattern="###,###"
-                                                                           value="${totalPrice}"/>đ</h5>
+                    <div class="me-3">
+                        <button type="button" class="btn btn-outline-dark px-4" data-bs-dismiss="modal" aria-label="Close">
+                          Tiếp tục chọn món
+                        </button>
                     </div>
-                    <div class="col-xl-2 col-lg-3 col-md-4 col-sm-4 align-self-end text-end">
+                    <div class="">
                         <%-- To solve the issue of submit button outside of the form element, just add "form" attribute --%>
-                        <button type="submit" class="btn btn-primary w-100" id="btnSubmit" name="btnSubmit" form="cart-form" value="Checkout">Thanh
-                            toán
+                        <button type="submit" class="btn btn-primary px-5" id="btnSubmit" name="btnSubmit" form="cart-form" value="Checkout">
+                          Thanh toán
                         </button>
                     </div>
                 </div>
@@ -102,25 +121,53 @@
         }
     }
 
+    $('.quantity-input').on('keydown', (e) => {
+      let key = e.key;
+      let isDigit = /^\d$/.test(key);
+      let isException = key === 'ArrowLeft' 
+        || key === 'ArrowRight' 
+        || key === 'Backspace'
+        || key === 'Delete';
+
+      // // TODO fix this mess here
+      // if (isDigit) {
+      //   if (this.val().toString().length >= 2) {
+      //     e.preventDefault();
+      //   }
+      // }
+      
+      // Check if the key is a number
+      if (!isDigit && !isException) {
+        e.preventDefault();
+      }
+    })
+
     // Add event listener for quantity input change event using event delegation
-    document.addEventListener("input", function (event) {
-        // Check if the changed element is a quantity input field
-        if (event.target.classList.contains("quantity-input")) {
-            // Get the parent row of the input field
-            const row = event.target.closest("tr");
-            // Get the price per unit of the food from the data attribute or other source
-            const pricePerUnitText = row.querySelector("td:nth-child(2)").textContent.trim();
-            const pricePerUnit = parseFloat(pricePerUnitText.replace("đ", "").replace(",", ""));
-            // Get the quantity entered by the user
-            const quantity = parseInt(event.target.value, 10);
-            // Calculate the new product price
-            const productPrice = pricePerUnit * quantity;
-            // Update the product price cell in the same row
-            row.querySelector("td:nth-child(4)").textContent = productPrice.toLocaleString() + "đ";
-            // Calculate and update the total price
-            updateTotalPrice();
-        }
-    });
+    $('.quantity-input').on('blur', (e) => {
+      // Get the parent row of the input field
+      const row = event.target.closest("tr");
+      const target = e.target;
+      // Get the price per unit of the food from the data attribute or other source
+      const pricePerUnitText = row.querySelector("td:nth-child(2)").textContent.trim();
+      const pricePerUnit = parseFloat(pricePerUnitText.replace("đ", "").replace(",", ""));
+      
+      // Get the quantity entered by the user
+      const currentQuantity = parseInt(event.target.value, 10);
+
+      // // Validates the user input, making sure it is within 1-10
+      // let newQuantity =
+      //   !isNaN(currentQuantity) && currentQuantity >= 1 && currentQuantity < 10 // user input is valid
+      //     ? currentQuantity
+      //     : 1; // default to 1
+      // target.val(newQuantity); // TODO fix this mess here
+      
+      // Calculate the new product price
+      const productPrice = pricePerUnit * newQuantity;
+      // Update the product price cell in the same row
+      $(tableRow).find(".item-total").html(formattedItemTotal + " đ");
+      // Calculate and update the total price
+      updateTotalPrice();
+    })
 
     // Function to update the total price based on all product prices
     function updateTotalPrice() {
@@ -133,8 +180,99 @@
             totalPrice += productPrice;
         });
         // Update the total price element
-        const totalPriceElement = document.querySelector(".modal-footer h5");
+        const totalPriceElement = document.querySelector("#grand-total");
         totalPriceElement.textContent = "Tổng thanh toán: " + totalPrice.toLocaleString() + "đ";
     }
+
+        /**
+     * Increments the value of a field by 1 when triggered by an event.
+     *
+     * @param {Event} e - The event object.
+     * @return {number} The new value.
+     */
+    function incrementValue(e) {
+      e.preventDefault();
+      let target = $(e.target);
+      let fieldName = target.data("field");
+      let parent = target.closest("div");
+      let quantityInput = parent.find("input[name=" + fieldName + "]");
+      let currentQuantity = parseInt(quantityInput.val(), 10);
+
+      // Set the new value, making sure it is within 1-10
+      let newQuantity =
+        !isNaN(currentQuantity) && currentQuantity >= 1 && currentQuantity < 10
+          ? currentQuantity + 1
+          : 10;
+      quantityInput.val(newQuantity);
+
+      return newQuantity;
+    }
+
+    /**
+     * Decrements the value of an input field by 1.
+     *
+     * @param {Event} e - The event object.
+     * @return {number} The new value.
+     */
+    function decrementValue(e) {
+      e.preventDefault();
+      let target = $(e.target);
+      let fieldName = target.data("field");
+      let parent = target.closest("div");
+      let quantityInput = parent.find("input[name=" + fieldName + "]");
+      let currentQuantity = parseInt(quantityInput.val(), 10);
+
+      // Set the new value, making sure it is within 1-10
+      let newQuantity =
+        !isNaN(currentQuantity) && currentQuantity > 1 && currentQuantity <= 10
+          ? currentQuantity - 1
+          : 1;
+      quantityInput.val(newQuantity);
+
+      return newQuantity;
+    }
+
+    /**
+     * Extracts the price from a string representation of a currency value.
+     *
+     * @param {string} str - The string representation of the currency value.
+     * @return {number} The price as a numeric value.
+     */
+    function getPrice(str) {
+      let trimmedStr = str
+        .substring(0, str.length - 2) // Removes currency symbol and space before it
+        .replace(",", ""); // Removes thousand separators
+      return parseInt(trimmedStr);
+    }
+
+    $(".input-group").on("click", ".button-plus", function (e) {
+      let quantity = incrementValue(e);
+      let target = $(e.target);
+      let tableRow = target.closest("tr");
+      let itemPriceStr = $(tableRow).find(".item-price").html();
+      let itemPrice = getPrice(itemPriceStr);
+      let itemTotal = itemPrice * quantity;
+
+      // Format the total price string so that it can be displayed correctly to the user
+      formattedItemTotal = itemTotal.toLocaleString();
+      $(tableRow).find(".item-total").html(formattedItemTotal + " đ");
+
+      updateTotalPrice();
+    });
+
+    $(".input-group").on("click", ".button-minus", function (e) {
+      let quantity = decrementValue(e);
+      let target = $(e.target);
+      let tableRow = target.closest("tr");
+      let itemPriceStr = $(tableRow).find(".item-price").html();
+      let itemPrice = getPrice(itemPriceStr);
+      let itemTotal = itemPrice * quantity;
+
+      // Format the total price string so that it can be displayed correctly to the user
+      formattedItemTotal = itemTotal.toLocaleString();
+      $(tableRow).find(".item-total").html(formattedItemTotal + " đ");
+
+      updateTotalPrice();
+    });
 
 </script>

--- a/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
+++ b/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
@@ -2,7 +2,7 @@
 <%@ page pageEncoding="UTF-8" %>
 <!-- Cart -->
 <div class="modal" tabindex="-1" id="cart-modal">
-    <div class="modal-dialog modal-xl modal-dialog-scrollable modal-dialog-centered">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable modal-dialog-centered modal-fullscreen-lg-down">
         <div class="modal-content px-4 py-3">
             <div class="modal-header pb-0 border-bottom-0">
                 <h4 class="modal-title" id="exampleModalLabel">Giỏ hàng</h5>
@@ -85,20 +85,14 @@
                     </div>
                 </form>
             </div>
-            <div class="modal-footer pt-0">
-                <div class="d-flex flex-row align-items-center justify-content-end w-100">
-                    <div class="me-3">
-                        <button type="button" class="btn btn-outline-dark px-4" data-bs-dismiss="modal" aria-label="Close">
-                          Tiếp tục chọn món
-                        </button>
-                    </div>
-                    <div class="">
-                        <%-- To solve the issue of submit button outside of the form element, just add "form" attribute --%>
-                        <button type="submit" class="btn btn-primary px-5" id="btnSubmit" name="btnSubmit" form="cart-form" value="Checkout">
-                          Thanh toán
-                        </button>
-                    </div>
-                </div>
+            <div class="modal-footer flex-wrap pt-0">
+              <button type="button" class="btn w-100 w-sm-auto btn-outline-dark px-4" data-bs-dismiss="modal" aria-label="Close">
+                Tiếp tục chọn món
+              </button>
+              <%-- To solve the issue of submit button outside of the form element, just add "form" attribute --%>
+              <button type="submit" class="btn w-100 w-sm-auto btn-primary px-5" id="btnSubmit" name="btnSubmit" form="cart-form" value="Checkout">
+                Thanh toán
+              </button>
             </div>
         </div>
     </div>

--- a/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
+++ b/src/main/webapp/WEB-INF/jspf/guest/components/cart.jspf
@@ -8,7 +8,7 @@
                 <h4 class="modal-title" id="exampleModalLabel">Giỏ hàng</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body">
+            <div class="modal-body py-2">
                 <%-- Putting form inside modal body ensures the modal's scrollability --%>
                 <form id="cart-form" action="checkout" method="POST">
                     <div class="table-responsive">
@@ -23,9 +23,18 @@
                                 </tr>
                             </thead>
                             <tbody class="table-group-divider">
-                            <p style="color: red;">${mess}</p>
+                            <p style="color: red;">${sessionScope.mess}</p>
                             <c:set var="totalPrice" value="0"></c:set>
-                            <c:forEach var="cart" items="${sessionScope['cart'].items}">
+                            <c:choose>
+                                <c:when test="${sessionScope['cart'].items.isEmpty() || sessionScope['cart'].items == null}">
+                                    <tr>
+                                        <td colspan="5" class="text-center">
+                                            <p id="empty-cart-label" class="fs-1 my-1">Giỏ hàng của bạn đang trống</p>
+                                        </td>
+                                    </tr>
+                                </c:when>
+                                <c:otherwise>
+                                  <c:forEach var="cart" items="${sessionScope['cart'].items}">
                                 <input type="text" name="fid" value="${cart.food.foodID}" hidden>
                                 <tr class="align-middle">
                                     <!-- Image and Food name -->
@@ -63,10 +72,12 @@
                                     </td>
                                 </tr>
                             </c:forEach>
+                            </c:otherwise>
+                            </c:choose>
                             </tbody>
                             <tfoot class="table-group-divider">
                               <th colspan="5" class="text-end">
-                                <h5 id="grand-total" class="mt-2">Tổng thanh toán: <fmt:formatNumber type="number" pattern="###,###"
+                                <h4 id="grand-total" class="mt-2">Tổng thanh toán: <fmt:formatNumber type="number" pattern="###,###"
                                   value="${totalPrice}"/> đ</h5>
                               </th>
                             </tfoot>
@@ -111,8 +122,9 @@
     // Get the number of rows in the cart table
     const numRows = cartTable.getElementsByTagName("tbody")[0].getElementsByTagName("tr").length;
 
-    // If there are no rows, disable the submit button and remove the cart badge
-    if (numRows === 0) {
+    // If there are no rows or there is an empty cart label, disable the submit button and remove the cart badge
+    // Otherwise, enable the submit button and add the cart badge
+    if (numRows === 0 || document.getElementById("empty-cart-label")) {
         document.getElementById("btnSubmit").disabled = true;
         cartBadge.classList.add("d-none");
     } else {

--- a/src/main/webapp/WEB-INF/jspf/guest/components/foodList.jspf
+++ b/src/main/webapp/WEB-INF/jspf/guest/components/foodList.jspf
@@ -1,8 +1,8 @@
 <%@ page pageEncoding="UTF-8" %>
-<div class="row row-cols-4 gx-3" id="food-list">
+<div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 gx-3" id="food-list">
   <!-- Gets foodList attribute set by HomeController.java -->
   <c:forEach items="${foodList}" var="food">
-    <div class="col-sm-6 col-md-4 col-lg-3 mb-4 h-100" id="food-${food.foodTypeID}">
+    <div class="food-card mb-4 h-100" id="food-${food.foodTypeID}">
       <div class="card card-span h-100 rounded-3 shadow">
         <div class="position-relative">
           <img class="card-img-top img-fluid rounded-3 h-100" src="${food.imageURL}" alt="${food.foodName}" />

--- a/src/main/webapp/assets/js/home.js
+++ b/src/main/webapp/assets/js/home.js
@@ -11,10 +11,10 @@ let itemsShown = 0;
 
 //show success order food
 $(document).ready(function () {
-  if (window.location.hash === '#success') {
-    $('#success').modal('show');
+  if (window.location.hash === "#success") {
+    $("#success").modal("show");
     setTimeout(function () {
-      $('#success').modal('hide');
+      $("#success").modal("hide");
     }, 3000);
   }
   showInitialFoodItems();
@@ -64,28 +64,27 @@ $(document).on("click", ".btn-categories", function () {
 });
 
 // Get all button addToCartBtn
-var addToCartButtons = document.querySelectorAll('.addToCartBtn');
+let addToCartButtons = document.querySelectorAll(".addToCartBtn");
 
 // Loop each button and add click event
-addToCartButtons.forEach(function(button) {
-  button.addEventListener('click', function() {
-    var foodId = this.getAttribute('data-foodid');
-    var quantity = this.getAttribute('data-quantity');
+addToCartButtons.forEach(function (button) {
+  button.addEventListener("click", function () {
+    let foodId = this.getAttribute("data-foodid");
+    let quantity = this.getAttribute("data-quantity");
     // Send AJAX request to addToCart servlet endpoint
     $.ajax({
-        type: "GET",
-        url: "addToCart",
-        data: {
-            fid: foodId,
-            quantity: quantity
-        },
-        success: function (response) {
-            console.log("Item added to cart successfully.");
-        },
-        error: function (error) {
-
-            console.error("Error occurred: " + error.responseText);
-        }
+      type: "GET",
+      url: "addToCart",
+      data: {
+        fid: foodId,
+        quantity: quantity,
+      },
+      success: function (response) {
+        console.log("Item added to cart successfully.");
+      },
+      error: function (error) {
+        console.error("Error occurred: " + error.responseText);
+      },
     });
     window.location.reload();
   });
@@ -113,7 +112,7 @@ function showInitialFoodItems() {
   }
 
   // Show the "show more" button if there are more items to show
-  autoHideButton()
+  autoHideButton();
 }
 
 // Add event listener to the "Xem thêm" button
@@ -146,7 +145,9 @@ function searchFoodByKeyword() {
 
   // Iterate through each food item
   for (let i = 0; i < foodList.length; i++) {
-    let foodName = foodList[i].querySelector(".card-title").textContent.toLowerCase();
+    let foodName = foodList[i]
+      .querySelector(".card-title")
+      .textContent.toLowerCase();
     let foodContainer = foodList[i];
 
     // Check if the search term is empty


### PR DESCRIPTION
I've decided not to remake the cart UI by following my own design on Figma because it's not practical for this project (and time-consuming). As such, I'll stick to the original design and improve on it.

# Features:
- Increase content padding
- Quantity input now has dedicated increment/decrement buttons (spin buttons)
- Add an icon to delete buttons; also reduce emphasis on them by using outline button variants instead
- Move Grand Total to table footer
- Add the "Continue shopping" button as a close cart modal button
- Add table hover
- Adjust column width so that they look more evenly distributed (on 1024+ px screens for now)
- Item total and Grand Total values are updated as item quantities change (still working on bugs for this one)
- Remove default spin buttons of quantity input fields (for the cart modal only)
- Modal becomes fullscreen on <1024px screens to prevent responsive issues on such screen size
- Primary (Checkout) and secondary (Continue shopping) buttons become full-width buttons on small (<576px) screens only

# Validation logic:
- Limits user input to a maximum of 2 digits, user-inputted value must be in the range of 1-10, anything outside of the said range will be ignored. The original value (before the user inputs the new value) will be restored in such cases.
- Restricts allowed input characters to digits, and arrow keys + backspace/delete keys for input navigation only. This ensures that the user cannot enter negative numbers or do math on it :smiley:

# Logic changes:
- Clicking "Thanh toán" while having an empty/null cart (POST request) should do the same, and add an error label to the cart modal. This error label should only appear when the user attempts to do something unexpected.
- Modifying URL to "/checkout" (GET request) when the cart is empty -> now return to "/" instead of "/home". Now, it also adds an error label like POST request.
- Add default empty cart label (not error label). This label should normally appear when a cart is empty.
- Change redirect URL to "/" instead of "/home". For this to happen I used session attributes instead of request attributes.

# Remaining problems:
- <678px screen width can still break the modal's table. I could fix this using flexbox, but I'll have to remove the entire table structure and build a new flexbox layout from scratch, which is time-consuming and could break related JS code as well.

# Screenshots:
![image](https://github.com/khengyun/FFood-shop/assets/88323009/b0e561c4-a28e-4ab2-bc30-47f32cfc8fe6)
![image](https://github.com/khengyun/FFood-shop/assets/88323009/d2bb35dd-1027-4563-a30f-35e13c29478b)
![image](https://github.com/khengyun/FFood-shop/assets/88323009/b2dfdce8-a5d7-4ef2-a351-ed5992d83469)

