### PR TITLE
Fix sections' not matching their siblings' height

### DIFF
--- a/src/main/webapp/WEB-INF/jspf/admin/insights.jspf
+++ b/src/main/webapp/WEB-INF/jspf/admin/insights.jspf
@@ -128,7 +128,7 @@
             <canvas id="revenueChart" width="400" height="200"></canvas> <!-- Thêm thẻ canvas cho biểu đồ -->
             <!-- Nội dung chương trình khuyến mãi -->
         </div>
-        <div class="p-4 col-5 shadow rounded-4 bg-white">
+        <div class="p-4 col-5 shadow rounded-4 bg-white align-self-stretch">
             <h2 class="text-start fs-2">Số lượng khách hàng</h2>
 
             <canvas id="customerChart" width="400" height="200"></canvas> <!-- Thêm thẻ canvas cho biểu đồ số lượng khách hàng -->
@@ -140,7 +140,7 @@
             <canvas id="averageOrderChart" width="400" height="200"></canvas> <!-- Thêm thẻ canvas cho biểu đồ đơn hàng trung bình -->
 
         </div>
-        <div class="p-4 col-5 shadow rounded-4 bg-white">
+        <div class="p-4 col-5 shadow rounded-4 bg-white align-self-stretch">
             <h2 class="text-start fs-2">Top 5 món bán chạy</h2>
             <% for (Models.MenuItem item : topSellingItems) {%>
             <div class="d-flex align-items-center">


### PR DESCRIPTION
# Note: PR #128 fixes a minor bug that causes entire website crash. Pls approve it first before checking this one.
Fix #117: sections' container height.
This feels... déjà vu?

![image](https://github.com/khengyun/FFood-shop/assets/88323009/dbe385a6-6a9a-497d-ba0f-ea950d12105f)
